### PR TITLE
fix(Dockerfile) add ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN chmod +x /usr/bin/volume-syncing-controller && chown root:root /usr/bin/volu
 # =========================
 FROM scratch
 
+# copy ca-certificates to work with some apis
+COPY --from=rcloneSrc /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 # copy a versioned artifact from official released image
 COPY --from=rcloneSrc /usr/local/bin/rclone /usr/bin/rclone
 # copy already built artifact by CI


### PR DESCRIPTION
## Context
Fix error with oauth2.googleapis.com ssl

```
...
2022/11/27 04:27:04 DEBUG : fs cache: renaming cache item "/data/" to be canonical "/data"
2022/11/27 04:27:04 DEBUG : Creating backend with remote "remote:/vaultwarden-sync/"
2022/11/27 04:27:04 DEBUG : remote: Loaded invalid token from config file - ignoring
2022/11/27 04:27:04 DEBUG : remote: Token refresh failed try 1/5: Post "https://oauth2.googleapis.com/token": x509: certificate signed by unknown authority
2022/11/27 04:27:05 DEBUG : remote: Loaded invalid token from config file - ignoring
2022/11/27 04:27:05 DEBUG : remote: Token refresh failed try 2/5: Post "https://oauth2.googleapis.com/token": x509: certificate signed by unknown authority
...
```